### PR TITLE
Workbench power and energy

### DIFF
--- a/esphome_workbench_energy.yaml
+++ b/esphome_workbench_energy.yaml
@@ -1,0 +1,88 @@
+substitutions:
+  system_name: workbench_energy
+  friendly_name: Esph Workbench Energy
+
+esphome:
+  name: "esph_${system_name}"
+  platform: ESP8266
+  board: esp01_1m
+
+  on_boot:
+    then:
+      - switch.turn_on: relay
+
+wifi:
+  ssid: !secret wifi_vlan1_ssid
+  password: !secret wifi_vlan1_password
+  fast_connect: true
+  
+  ap:
+    ssid: "${friendly_name} AP"
+    password: !secret fallback_ssid_password
+
+captive_portal:
+
+#debug:
+
+logger:
+  level: DEBUG
+
+api:
+  password: !secret api_password
+
+ota:
+  password: !secret ota_password
+
+# web_server:
+#   port: 80
+
+uart:
+  rx_pin: RX
+  baud_rate: 4800
+
+text_sensor:
+
+  - platform: version
+    name: "esph_${system_name}_version"
+
+sensor:
+
+  - platform: wifi_signal
+    name: "esph_${system_name}_wifi_signal"
+    update_interval: 30s
+
+  - platform: uptime
+    name: "esph_${system_name}_uptime"
+    update_interval: 60s
+
+  - platform: cse7766
+    current:
+      name: "esph_${system_name}_current"
+    voltage:
+      name: "esph_${system_name}_voltage"
+    power:
+      name: "esph_${system_name}_power"
+
+switch:
+
+  - platform: gpio
+    name: "esph_${system_name}_relay"
+    pin: GPIO12
+    id: relay
+
+  - platform: restart
+    name: "esph_${system_name}_restart"
+
+  - platform: shutdown
+    name: "esph_${system_name}_shutdown"
+
+# output:
+#   - platform: esp8266_pwm
+#     id: blue_led
+#     pin: GPIO13
+#     inverted: True
+
+# light:
+#   - platform: monochromatic
+#     name: "esph_${system_name}_led"
+#     output: blue_led

--- a/esphome_workbench_plugs.yaml
+++ b/esphome_workbench_plugs.yaml
@@ -1,0 +1,99 @@
+substitutions:
+  system_name: workbench_plugs
+  friendly_name: Esph Solder Energy
+
+esphome:
+  name: "esph_${system_name}"
+  platform: ESP8266
+  board: esp01_1m
+
+wifi:
+  ssid: !secret wifi_vlan1_ssid
+  password: !secret wifi_vlan1_password
+  fast_connect: true
+  ap:
+    ssid: "${friendly_name} AP"
+    password: !secret fallback_ssid_password
+
+captive_portal:
+
+#debug:
+
+logger:
+  level: DEBUG
+
+api:
+  password: !secret api_password
+
+ota:
+  password: !secret ota_password
+
+
+text_sensor:
+
+  - platform: version
+    name: "esph_${system_name}_version"
+
+binary_sensor:
+
+  - platform: gpio
+    pin:
+      number: GPIO10
+      mode: INPUT_PULLUP
+      inverted: True
+    name: "esph_${system_name}_button0"
+    
+    #toggle both relays on push
+    on_press:
+      - switch.toggle: relay1
+      - switch.toggle: relay2
+
+  - platform: gpio
+    pin:
+      number: GPIO00
+      mode: INPUT_PULLUP
+      inverted: True
+    name: "esph_${system_name}_button1"
+    
+    #toggle only relay1
+    on_press:
+      - switch.toggle: relay1
+
+  - platform: gpio
+    pin:
+      number: GPIO09
+      mode: INPUT_PULLUP
+      inverted: True
+    name: "esph_${system_name}_button2"
+    
+    #toggle only relay2
+    on_press:
+      - switch.toggle: relay2
+
+sensor:
+
+  - platform: wifi_signal
+    name: "esph_${system_name}_wifi_signal"
+    update_interval: 30s
+
+  - platform: uptime
+    name: "esph_${system_name}_uptime"
+    update_interval: 60s
+
+switch:
+
+  - platform: restart
+    name: "esph_${system_name}_restart"
+
+  - platform: shutdown
+    name: "esph_${system_name}_shutdown"
+    
+  - platform: gpio
+    name: "esph_${system_name}_relay1"
+    pin: GPIO12
+    id: relay1
+
+  - platform: gpio
+    name: "esph_${system_name}_relay2"
+    pin: GPIO05
+    id: relay2


### PR DESCRIPTION
# Sonoff DUALR2
I'm using a Sonoff DualR2 to switch on a power extension for my soldering iron and a USB fan and a second switch on a power extension for a workbench light and other devices when I am working.

# Sonoff POWR2 
This is used to monitor the energy I am using between the above two extension leads. I should be able to see if my soldering iron is in use and if it is idling for a period switch it off.

Relates to jcallaghan/home-assistant-config#45